### PR TITLE
utilize CODEOWNERS file to protect chain information from unauthorized changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS defines individuals or teams that are
+# responsible for code in this repository.
+#
+# For documentation please read:
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+#
+
+# Order is important; the last matching pattern takes the most
+# precedence.
+
+# Set global owners. Also affects the CODEOWNERS file.
+
+*                 @okwme @jackzampolin @cosmos/ape-unit_registry_write
+
+# Set owner of each subfolder. The `/` is important.
+
+/akashnet-1/      @jackzampolin
+/cosmoshub-3/     @jackzampolin
+/pooltoy-2/       @okwme


### PR DESCRIPTION
A proposal to use `CODEOWNERS` file to manage ownership of chain registry information to protect chain registry entries from unauthorized changes. `CODEOWNERS` file "define individuals or teams that are responsible for code in a repository".
"Code owners are automatically requested for review when someone opens a pull request that modifies code that they own."

When adding a new chain registry entry, one should make an amendment to `CODEOWNERS` file in the same PR where the sub-folder with the respective chain metadata is added.

https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners